### PR TITLE
Address `TypeError: unorderable types: datetime.datetime() < str()`

### DIFF
--- a/KeepToOrg.py
+++ b/KeepToOrg.py
@@ -198,7 +198,7 @@ def main(keepHtmlDir, outputDir):
         # TODO: Make sure tags are filename-safe
         outFileName = '{}/{}.org'.format(outputDir, makeSafeFilename(tag))
 
-        notesSortedByDate = sorted(group, key=lambda note: note.date)
+        notesSortedByDate = sorted(group, key=lambda note: str(note.date))
         # If capture etc. appends, we should probably follow that same logic (don't reverse)
         # notesSortedByDate.reverse()
 


### PR DESCRIPTION
Addresses the following behavior:

```
Looking for notes in ...
Found 550 notes
Wrote 6 notes to ...
Wrote 9 notes to ...
Wrote 3 notes to ...
Traceback (most recent call last):
  File "/home/user/opt/KeepToOrg/KeepToOrg.py", line 232, in <module>
    main(keepHtmlDir, outputDir)
  File "/home/user/opt/KeepToOrg/KeepToOrg.py", line 201, in main
    notesSortedByDate = sorted(group, key=lambda note: note.date)
TypeError: unorderable types: datetime.datetime() < str()
```

With proposed change:

```
$ python3   ~/opt/KeepToOrg/KeepToOrg.py ...
Looking for notes in ...
Found 550 notes
Wrote 2 notes to ...
...
Wrote 554 notes total
$
```